### PR TITLE
csproj update to run on .NET Core 2.1

### DIFF
--- a/bootcamp-core-ui.csproj
+++ b/bootcamp-core-ui.csproj
@@ -6,11 +6,11 @@
     <Folder Include="wwwroot\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore" Version="1.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.1.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.1.2" />
     <PackageReference Include="Pivotal.Discovery.Client" Version="1.0.1" />
     <PackageReference Include="Steeltoe.Extensions.Configuration.CloudFoundry" Version="1.1.0" />
-    <PackageReference Include="System.Net.Http" Version="4.3.2" />
+    <PackageReference Include="System.Net.Http" Version="4.3.3" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
In Pivotal Bootcamp right now in Microsoft Technology Centers, Irvine
Found issue in compiling this SampleUI with .NET Core 2.1
This csproj modification fixes it:

Remove version for "Microsoft.AspNetCore"
Increase version of "System.Net.Http" to 4.3.3